### PR TITLE
Fix discrepancy related to Example 2.8 (Using gradle.properties)

### DIFF
--- a/ch02/MyApplication/gradle.properties
+++ b/ch02/MyApplication/gradle.properties
@@ -20,6 +20,6 @@
 org.gradle.jvmargs=-Xmx2048M
 login=user
 
-user=user_from_build_file
-pass=pass_from_build_file
+user=user_from_gradle_properties
+pass=pass_from_gradle_properties
 


### PR DESCRIPTION
The property value used in the book example, `user_from_gradle_properties`, was not matching the value within the codebase, which is `user_from_build_file`. This may be a little bit confusing when running the code from the codebase since the `output` is the same for :
- properties defined in the `build.gradle`
- properties defined in the `gradle.properties`

I hope it helps @kousen :)
